### PR TITLE
Fix mailto on links to email addresses

### DIFF
--- a/getinvolved.md
+++ b/getinvolved.md
@@ -6,11 +6,11 @@ title: "Get Involved"
 
 Most easily send us an email if you are interested in details or want
 to get involved: <a
-href="info@fossi-foundation.org">info@fossi-foundation.org</a>.
+href="mailto:info@fossi-foundation.org">info@fossi-foundation.org</a>.
 
 For discussion among members and interested people we have a mailing
 list at <a
-href="discussion@fossi-foundation.org">discussion@fossi-foundation.org</a>
+href="mailto:discussion@fossi-foundation.org">discussion@fossi-foundation.org</a>
 (<a
 href="https://lists.fossi-foundation.org/listinfo/discussion">subscribe
 here</a>). A few of us are also hanging out on IRC (#fossi at


### PR DESCRIPTION
Noticed these weren't working on the site, so added the missing scheme