### PR TITLE
GsoC 21: Updates for Staffords projects

### DIFF
--- a/gsoc21-ideas.md
+++ b/gsoc21-ideas.md
@@ -246,16 +246,6 @@ Verilog simulators don’t scale well in speed when hardware designs become very
 
 *Mentor:* Jonathan Balkind
 
-### Continuous Integration for OpenRISC mor1kx
-
-The [OpenRISC](http://openrisc.io/) project dates back to 2000 and defines an open source RISC architecture.  The current implementation of the architecture [mor1kx](https://github.com/openrisc/mor1kx) has a constantly evolving code base which is sometimes found to have bugs.  This project would be to extend the continuous integration (CI) system to test changes to mor1kx to ensure there are no regressions.  The CI should verify the core by running [or1k-tests](https://github.com/openrisc/or1k-tests), check that debugging features work with OpenOCD/GDB and monitor resource usages by running yosys synthesis.  The tests should also run with different options enabled for the codebase, i.e. caches enabled/disabled, load store buffers, pipelines CAPPUCCINO, MAROCCHINO, ESPRESSO.
-
-*Skill level:* Beginner
-
-*Language/Tools:* Verilog, Shell, Travis CI
-
-*Mentor:* [Stafford Horne](mailto:shorne@gmail.com)
-
 ### OpenRISC formal
 
 The [OpenRISC](http://openrisc.io/) project dates back to 2000 and defines an open source RISC architecture.  With the recent developments with [Yosys formal](http://www.clifford.at/papers/2016/yosys-synth-formal/) it is now possible for us to provide formal verification for the OpenRISC cores like [mor1kx](https://github.com/openrisc/mor1kx).  This project will be to start to formally verify the subsystems of the [mor1kx](https://github.com/openrisc/mor1kx) OpenRISC implementation.  This will help generate interest from companies that know of OpenRISC but haven't chosen it due to unknowns about stability.
@@ -263,6 +253,16 @@ The [OpenRISC](http://openrisc.io/) project dates back to 2000 and defines an op
 *Skill level:* Intermediate
 
 *Language/Tools:* Verilog, OpenRISC, yosys
+
+*Mentor:* [Stafford Horne](mailto:shorne@gmail.com)
+
+### Embench IoT OpenRISC port
+
+The [Embench](https://www.embench.org/news.html) benchmark suite is a modern tool used to measure embedded processor and compiler toolchain performance.  The [Embench IoT project](https://github.com/embench/embench-iot) has ports for ARM, RISC-V and other embedded processors.  The goal of this project will be to port Embench to run the OpenRISC toolchain and collect benchmarks.  The benchmarks should be recorded at [Embench IoT results](https://github.com/embench/embench-iot-results) to be able to compare OpenRISC vs other popular CPUs.
+
+*Skill level:* Easy
+
+*Language/Tools:* Shell scripting, C, Makefile, Python
 
 *Mentor:* [Stafford Horne](mailto:shorne@gmail.com)
 


### PR DESCRIPTION
Removed the CI work as its done.  Add project for embench IoT for openrisc.