### PR TITLE
One more SiliconCompiler project idea

### DIFF
--- a/gsoc22-ideas.md
+++ b/gsoc22-ideas.md
@@ -768,17 +768,21 @@ that we are testing is a browser-based visualization of a job's results.
 This lets users view a small preview of the GDS result, alongside various metrics
 reported by each task in the physical design flow.
 
-We would like to improve the way that data is presented and add more information
-from the SiliconCompiler job manifests, so this would be a great project for a
-developer interested in frontend development and/or data visualization!
+We would like to improve the way that this data is presented, and add more information
+from the SiliconCompiler job manifests. This would be a great project for someone
+interested in frontend development and/or data visualization!
+
+This is an example of the sort of report which you would be working on:
+
+![exampleReport](https://user-images.githubusercontent.com/5217539/162544399-3c83d667-35b4-4013-b373-ae42c00c4ad6.png)
 
 We have a few improvements in mind, but we would also welcome suggestions:
 
 - Past Results: SiliconCompiler retains metrics from past builds, which we would like to display.
 - Data Visualization: We would like to explore options beyond simple tables for visualizing metrics within and across job runs.
 - Input Parameters: In addition to a job's results, we would like to include the values of configurable inputs in our reports.
-- Modal Dialogs: There is some content which we would like to display in 'hover-over' modals, rather than linking to them.
-- "Flowgraph" visualization: We would like to display which individual tasks were run over the course of the job, in the correct order. SiliconCompiler currently uses graphviz to generate diagrams of these "flowgraphs".
+- Modal Dialogs: There is some content which we would like to display in 'hover-over' modals, rather than linking to it.
+- "Flowgraph" Visualization: SiliconCompiler can generate diagrams describing which tasks ran over the course of a job, and we would like to include those in our reports.
 
 *Skill Level:* Beginner
 

--- a/gsoc22-ideas.md
+++ b/gsoc22-ideas.md
@@ -759,7 +759,7 @@ likely involve work on tool drivers for any non-Verilog frontends used.
 
 *Language/tools:* Python, Yosys, OpenROAD, Verilog, other HDLs depending on cores chosen
 
-*Mentors:* [Noah Moroze](mailto:noah@zeroasic.com), Will Ransohoff
+*Mentors:* [Noah Moroze](mailto:noah@zeroasic.com), [Will Ransohoff](mailto:will@zeroasic.com)
 
 ### Interactive SiliconCompiler design summaries
 
@@ -772,11 +772,7 @@ We would like to improve the way that this data is presented, and add more infor
 from the SiliconCompiler job manifests. This would be a great project for someone
 interested in frontend development and/or data visualization!
 
-This is an example of the sort of report which you would be working on:
-
-![exampleReport](https://user-images.githubusercontent.com/5217539/162544399-3c83d667-35b4-4013-b373-ae42c00c4ad6.png)
-
-We have a few improvements in mind, but we would also welcome suggestions:
+[This is what our reports currently look like.](https://user-images.githubusercontent.com/5217539/162544399-3c83d667-35b4-4013-b373-ae42c00c4ad6.png) We have a few improvements in mind, but we would also welcome suggestions:
 
 - Past Results: SiliconCompiler retains metrics from past builds, which we would like to display.
 - Data Visualization: We would like to explore options beyond simple tables for visualizing metrics within and across job runs.

--- a/gsoc22-ideas.md
+++ b/gsoc22-ideas.md
@@ -761,3 +761,29 @@ likely involve work on tool drivers for any non-Verilog frontends used.
 
 *Mentors:* [Noah Moroze](mailto:noah@zeroasic.com), Will Ransohoff
 
+### Interactive SiliconCompiler design summaries
+
+SiliconCompiler produces automated reports for its designs, and one format
+that we are testing is a browser-based visualization of a job's results.
+This lets users view a small preview of the GDS result, alongside various metrics
+reported by each task in the physical design flow.
+
+We would like to improve the way that data is presented and add more information
+from the SiliconCompiler job manifests, so this would be a great project for a
+developer interested in frontend development and/or data visualization!
+
+We have a few improvements in mind, but we would also welcome suggestions:
+
+- Past Results: SiliconCompiler retains metrics from past builds, which we would like to display.
+- Data Visualization: We would like to explore options beyond simple tables for visualizing metrics within and across job runs.
+- Input Parameters: In addition to a job's results, we would like to include the values of configurable inputs in our reports.
+- Modal Dialogs: There is some content which we would like to display in 'hover-over' modals, rather than linking to them.
+- "Flowgraph" visualization: We would like to display which individual tasks were run over the course of the job, in the correct order. SiliconCompiler currently uses graphviz to generate diagrams of these "flowgraphs".
+
+*Skill Level:* Beginner
+
+*Duration:* 175 hours
+
+*Languate/tools:* Python (+Jinja), JS, HTML/CSS
+
+*Mentors:* [Will Ransohoff](mailto:will@zeroasic.com)


### PR DESCRIPTION
Hi there - this is our other project idea from SiliconCompiler. We would like to explore improvements to a browser-viewable report summary which we generate for each job run. This is more focused on frontend design than many other entries, so we understand if it is not quite in-line with the project's scope, but we have several ideas for developers who are interested in data visualization and web templating.

Our current reports include a simple preview and metrics table, with links to relevant log files. Here's an example generated from a minimal test design running through OpenROAD/skywater130 (I can remove this from the .md file if it is distracting):

![report_draft](https://user-images.githubusercontent.com/5217539/162544399-3c83d667-35b4-4013-b373-ae42c00c4ad6.png)

We would like to explore other methods of visualizing these metrics, and incorporate more information from the SiliconCompiler manifests, such as metrics from past runs with different parameters.

Thank you!